### PR TITLE
docs(github-pages-deployment): add fix-pages-build spec

### DIFF
--- a/.agents/context/glossary.md
+++ b/.agents/context/glossary.md
@@ -20,6 +20,7 @@
 
 ## Branch Change Summary
 
+- Pages deployment spec: added `openspec/changes/fix-pages-build/` (proposal, tasks, spec delta) to address GitHub Pages build failures caused by Jekyll parsing Astro sources.
 - OpenSpec updates: `openspec/project.md`, `openspec/contributing.md`, `openspec/changes/update-site-quality-checks/` (proposal, tasks, specs), updates to `openspec/changes/refactor-content-collections/`, and new `openspec/changes/refactor-styling-architecture/`.
 - Copilot integration: implemented `openspec/changes/add-copilot-integration/` with `.github/workflows/copilot-setup-steps.yml` and documented it in `README.md` (issue #6).
 - Copilot context: added root `COPILOT.md` and linked it with `openspec/AGENTS.md`.

--- a/openspec/changes/fix-pages-build/proposal.md
+++ b/openspec/changes/fix-pages-build/proposal.md
@@ -1,0 +1,16 @@
+## Why
+
+GitHub Pages is attempting to run the default Jekyll build against Astro source files, which fails on `.astro` front matter and blocks deployments after merges.
+
+## What Changes
+
+- Ensure GitHub Pages deploys from the Astro build artifact produced by `.github/workflows/deploy.yml`.
+- Prevent Jekyll processing of published assets by adding a `.nojekyll` marker.
+- Add a safe Jekyll fallback configuration that excludes Astro sources if branch builds remain enabled.
+- Document the required Pages source setting (GitHub Actions) for maintainers.
+
+## Impact
+
+- Affected specs: github-pages-deployment
+- Affected code: `public/.nojekyll`, `_config.yml`, documentation for Pages settings
+- Affected systems: GitHub Pages repository settings

--- a/openspec/changes/fix-pages-build/specs/github-pages-deployment/spec.md
+++ b/openspec/changes/fix-pages-build/specs/github-pages-deployment/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: GitHub Pages deploys from the Astro workflow
+The GitHub Pages site SHALL deploy from the Astro build workflow defined in `.github/workflows/deploy.yml`.
+
+#### Scenario: Pages source is GitHub Actions
+- **WHEN** GitHub Pages is configured for deployment
+- **THEN** the Pages source is set to GitHub Actions and the Astro workflow is the authoritative build pipeline.
+
+### Requirement: Published site bypasses Jekyll
+The published site SHALL include a `.nojekyll` marker file.
+
+#### Scenario: Jekyll is disabled for published assets
+- **WHEN** the Pages site is served
+- **THEN** Jekyll processing is bypassed and the static assets are served as built.
+
+### Requirement: Jekyll fallback excludes Astro sources
+The repository SHALL include a Jekyll configuration that excludes Astro source directories from Pages builds if branch-based builds are enabled.
+
+#### Scenario: Branch-based build is still enabled
+- **WHEN** GitHub Pages runs a branch-based build
+- **THEN** Jekyll ignores Astro sources and the build completes without front matter errors.
+
+### Requirement: Pages source setting is documented
+Project documentation SHALL state that the GitHub Pages source must be set to GitHub Actions and reference the Astro deploy workflow.
+
+#### Scenario: Maintainers verify Pages configuration
+- **WHEN** a maintainer reviews deployment documentation
+- **THEN** they can confirm the Pages source setting and the workflow responsible for deployments.

--- a/openspec/changes/fix-pages-build/tasks.md
+++ b/openspec/changes/fix-pages-build/tasks.md
@@ -1,0 +1,5 @@
+- [ ] Add spec deltas for GitHub Pages deployment in `openspec/changes/fix-pages-build/specs/github-pages-deployment/spec.md`.
+- [ ] Add `public/.nojekyll` to ensure published artifacts bypass Jekyll.
+- [ ] Add `_config.yml` to exclude Astro sources from any branch-based Jekyll build.
+- [ ] Document that GitHub Pages source must be set to GitHub Actions and reference `deploy.yml`.
+- [ ] Run `openspec validate fix-pages-build --strict` and resolve findings.


### PR DESCRIPTION
Adds the OpenSpec proposal + spec delta for the GitHub Pages build failure caused by Jekyll parsing Astro sources.

OpenSpec: openspec/changes/fix-pages-build/
Spec delta: openspec/changes/fix-pages-build/specs/github-pages-deployment/spec.md

Refs #9