### PR TITLE
docs(site-content): clarify markdown pipeline guidance

### DIFF
--- a/.agents/context/glossary.md
+++ b/.agents/context/glossary.md
@@ -20,6 +20,7 @@
 
 ## Branch Change Summary
 
+- Copilot review spec: clarified that FAQ Markdown rendering must use the shared Astro Markdown pipeline for consistency with content collections.
 - Copilot review spec: added `openspec/changes/fix-copilot-review-issues/specs/site-content/spec.md`, created tasks, and aligned proposal/design references to `vision.mdx`.
 - OpenSpec archive: moved `openspec/changes/fix-pages-build/` to `openspec/changes/archive/2025-12-29-fix-pages-build/` and generated `openspec/specs/github-pages-deployment/spec.md`.
 - Pages build fix implementation: added `public/.nojekyll` and `_config.yml` fallback excludes plus documented GitHub Pages source settings in `README.md`; marked `openspec/changes/fix-pages-build/tasks.md` complete.

--- a/openspec/changes/fix-copilot-review-issues/specs/site-content/spec.md
+++ b/openspec/changes/fix-copilot-review-issues/specs/site-content/spec.md
@@ -8,7 +8,7 @@ Content markdown files that include raw HTML SHALL use 2-space indentation for n
 - **THEN** embedded HTML blocks use 2-space indentation and remain Prettier-compliant.
 
 ### Requirement: FAQ answers are rendered from Markdown
-FAQ answers SHALL be stored as Markdown strings and rendered with Astro's Markdown renderer; direct HTML injection via `set:html` MUST NOT be used.
+FAQ answers SHALL be stored as Markdown strings and rendered with Astro's Markdown pipeline (aligned with the project's content collection rendering); direct HTML injection via `set:html` MUST NOT be used.
 
 #### Scenario: FAQ rendering avoids HTML injection
 - **WHEN** FAQ items are rendered in `src/components/FaqItem.astro`
@@ -17,3 +17,7 @@ FAQ answers SHALL be stored as Markdown strings and rendered with Astro's Markdo
 #### Scenario: FAQ data is Markdown
 - **WHEN** FAQ answers are authored in `src/data/faq.ts`
 - **THEN** the answers use Markdown formatting rather than raw HTML strings.
+
+#### Scenario: Shared Markdown pipeline
+- **WHEN** FAQ answers are rendered
+- **THEN** the Markdown is processed through the project's configured Astro Markdown pipeline for consistent output with content collections.


### PR DESCRIPTION
## Summary
- require FAQ Markdown rendering to use the shared Astro Markdown pipeline
- update agent context summary

## Testing
- openspec validate fix-copilot-review-issues --strict

Refs #14