### PR TITLE
fix(ci): purge Cloudflare cache after deploy — fix stale-HTML / SRI-mismatch render

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,3 +37,70 @@ jobs:
       - name: Deploy to Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+
+      # pt449 — Purge Cloudflare cache after every deploy.
+      #
+      # Why: artagon.com is fronted by Cloudflare proxy (orange-cloud
+      # DNS). Cloudflare caches HTML at the edge for the duration of
+      # the origin's `Cache-Control: max-age=600` (GitHub Pages
+      # default). After a deploy, users hitting Cloudflare's stale HTML
+      # for up to 10 minutes load asset URLs from a previous build —
+      # the new dist/ has different content-hashed filenames, so SRI
+      # rejects the mismatched assets and the page renders unstyled.
+      #
+      # The post-deploy purge tells Cloudflare to drop its edge cache
+      # for the zone, so the very next request fetches the fresh HTML
+      # with current asset hashes.
+      #
+      # GATING: this step runs ONLY when both secrets are present, so
+      # the deploy doesn't fail before the operator adds the credentials.
+      # Once `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ZONE_ID` land in
+      # repo secrets, the purge fires automatically on every deploy.
+      #
+      # Token scope: the API token MUST have the `Zone.Cache Purge`
+      # permission scoped to the `artagon.com` zone (and ONLY that
+      # zone). Use Cloudflare's "Custom token" template, NOT a
+      # global API key.
+      #
+      # The cf/api-token-action style integrates auth + curl in one
+      # step but introduces a third-party action dependency; using
+      # raw curl against the Cloudflare REST API is dependency-free
+      # and the token is masked by GitHub Actions automatically.
+      - name: Purge Cloudflare cache
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+        run: |
+          set -euo pipefail
+          # GitHub Actions doesn't allow `secrets.*` directly in `if:`
+          # conditions (would risk leaking via expression-eval logs).
+          # Gate inside the script instead: skip-not-fail when either
+          # secret is missing, so the deploy stays green before the
+          # operator adds the credentials.
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ] || [ -z "${CLOUDFLARE_ZONE_ID:-}" ]; then
+            echo "⚠ CLOUDFLARE_API_TOKEN or CLOUDFLARE_ZONE_ID not set; skipping cache purge."
+            echo "  Browsers may see stale HTML referencing prior-deploy asset hashes for up"
+            echo "  to 10 minutes (GH Pages default \`Cache-Control: max-age=600\`)."
+            echo "  To enable: \`gh secret set CLOUDFLARE_API_TOKEN\` and \`gh secret set"
+            echo "  CLOUDFLARE_ZONE_ID\` (token scope: Zone.Cache Purge on artagon.com)."
+            exit 0
+          fi
+          response=$(curl -sS -w "\n%{http_code}" \
+            -X POST \
+            "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data '{"purge_everything":true}')
+          body=$(printf '%s\n' "$response" | sed '$d')
+          status=$(printf '%s\n' "$response" | tail -n1)
+          if [ "$status" != "200" ]; then
+            echo "✗ Cloudflare purge failed (HTTP $status):"
+            printf '%s\n' "$body"
+            exit 1
+          fi
+          if ! printf '%s' "$body" | grep -q '"success":true'; then
+            echo "✗ Cloudflare reports purge unsuccessful:"
+            printf '%s\n' "$body"
+            exit 1
+          fi
+          echo "✓ Cloudflare cache purged for zone ${CLOUDFLARE_ZONE_ID}"


### PR DESCRIPTION
## Why

artagon.com is fronted by Cloudflare proxy (orange-cloud DNS — `104.26.x` / `172.67.x`). Cloudflare caches HTML at the edge for the duration of the origin's `Cache-Control: max-age=600` (GitHub Pages' default).

**Repro**: after a deploy, visitors hitting Cloudflare's stale HTML for up to **10 minutes** load asset URLs from a previous build. The new \`dist/\` has different content-hashed filenames (\`/_astro/Footer.NEW.css\` vs the cached HTML's \`/_astro/Footer.OLD.css\`), so the \`integrity=\` SRI on the fresh \`<link>\` rejects the now-mismatched cached asset → **page renders unstyled** until cache expires (or hard reload).

This was visible just now after PR #50's deploy: visitor saw default-browser fonts / blue underlined links / no theme styles for several minutes; \`⌘+Shift+R\` fixed it.

## What

Add a post-deploy step in \`.github/workflows/deploy.yml\` that POSTs to Cloudflare's \`/zones/{id}/purge_cache\` API with \`purge_everything: true\`. Edge cache drops immediately; next request fetches fresh HTML with current asset hashes → SRI passes → page styled correctly.

## Gating

GitHub Actions doesn't allow \`secrets.*\` directly in \`if:\` conditions (would risk leaking via expression-eval logs). Gate **inside the bash script**: skip-not-fail when \`CLOUDFLARE_API_TOKEN\` or \`CLOUDFLARE_ZONE_ID\` is missing. The deploy stays green before the operator adds the credentials — with a clear message in CI logs about how to enable.

## Operator setup (one-time)

```
# 1. Cloudflare → My Profile → API Tokens → Create Custom Token:
#    Zone.Cache Purge → artagon.com  (zone-only, NOT global API key)
# 2. Cloudflare dashboard → artagon.com → API tab → Zone ID
# 3. Add both to repo secrets:
gh secret set CLOUDFLARE_API_TOKEN --repo artagon/artagon-site
gh secret set CLOUDFLARE_ZONE_ID --repo artagon/artagon-site
```

After both land, every push to \`main\` triggers deploy + cache purge in sequence. No more 10-min stale window.

## Implementation notes

- **Raw curl, no third-party action** — dependency-free; the token is masked by Actions automatically; success criterion is explicit (HTTP 200 + \`"success":true\` in the JSON body).
- **\`set -euo pipefail\`** — curl failures (network, auth, malformed response) hard-fail the deploy step rather than masking the issue.
- **Token scope must be Zone-only** — documented in the inline comment so a future maintainer doesn't reach for a global API key.

## Test plan

- [ ] Merge this PR — deploy step shows the \`⚠ ... not set; skipping\` message (skip-not-fail path)
- [ ] Operator adds the two secrets via \`gh secret set\`
- [ ] Trigger a deploy (push or \`workflow_dispatch\`) — purge step shows \`✓ Cloudflare cache purged for zone ...\`
- [ ] Verify by deploying any small change and immediately fetching \`https://artagon.com\` — expect \`cf-cache-status: MISS\` (or \`EXPIRED\` → \`HIT\` after first repopulate), not \`HIT\` of pre-deploy content.

## Follow-up (not blocked)

The cleanest long-term fix is the \`migrate-deploy-to-cloudflare-pages\` OpenSpec change, which moves the origin from GitHub Pages to Cloudflare Pages with proper \`_headers\` setting \`Cache-Control: public, max-age=0, must-revalidate\` on HTML. This PR is the tactical patch in the meantime.